### PR TITLE
Adds a PR template and a short contributing explainer

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+![A depiction of the 'RAIN WORLD' title screen, featuring Nomad.](mod/decals/Notocorda_TitleScreen.png)
+
+## Introduction
+The following is a general guide on how to help out for an open-source C# project like this, for those unfamiliar with typical etiquette and expectations. **These are not rules**, just some common wisdom that will make it easier for you to get your code merged and this mod further on its way to being complete! ❤️
+
+## Basics
+- **Don't merge your own PR.** Unless it's important or beyond all reasonable doubt that you did it perfectly, wait for someone else to merge it.
+- **Try to ask for help when you don't understand something.** A lot of the info about the Rain World engine is not easily available online, but you may get a good answer if you just ask. Nobody is expected to know everything and nobody deserves wasting 10 hours on figuring something out all over again by themselves. *Don't be a Pebbles.*
+
+## Code Style
+There's no set style, but here's some recommendations:
+
+- Use file-wide namespaces instead of namespace blocks. This means writing `namespace Deadlands;` instead of `namespace Deadlands { /* ... all the code ... */ }`.
+- Never use `unsafe`.
+- Be communicative! Code you write is, in part, a conversation you are having with the rest of us. Explain yourself, use clear variable names, and keep it simple.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+<!-- 
+Thanks for making a PR! The following is a template demonstrating some things to mention in a PR submission.
+You don't need to follow this to the letter and may remove parts that are irrelevant to your PR.
+-->
+
+<!--
+If possible & relevant, include a screenshot here that depicts what's new in the game, as it appears in your branch.
+-->
+
+## Summary
+<!-- Summarize what you did here. -->
+
+## Changelog
+<!--
+Please have a bullet-point changelog of what is now different in the game, from the players' perspective.
+If there are changes that aren't user-facing, discuss them in the summary instead.
+-->


### PR DESCRIPTION
## Summary
This adds a little template that will appear whenever anyone submits a PR, recommending that they provide a short summary and changelog. I also made a little markdown explainer which goes over some basic etiquette that's typical for an open-source project.

Most of this is pretty bureaucratic and nobody necessarily has to abide by it, I just wanted to fill these out for those worried they are doing something wrong or are unfamiliar with how to work in spaces like this. ❤️ 

## Changelog
No user-facing changes.