### PR TITLE
Adds a build script to generate a Symbolic Link to the Rain World mod folder, automagically

### DIFF
--- a/src/Deadlands.csproj
+++ b/src/Deadlands.csproj
@@ -3,6 +3,14 @@
         <TargetFramework>net48</TargetFramework>
         <LangVersion>12</LangVersion>
     </PropertyGroup>
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+      <DebugType>portable</DebugType>
+      <WarningLevel>5</WarningLevel>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+      <DebugType>portable</DebugType>
+      <WarningLevel>5</WarningLevel>
+    </PropertyGroup>
 	
        <Target Name="GenerateMod" AfterTargets="PostBuildEvent">
 		   
@@ -26,5 +34,9 @@
             <Private>false</Private>
         </Reference>
     </ItemGroup>
+	
+    <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+      <Exec Command="call symlinkHandler.bat" />
+    </Target>
     
 </Project>

--- a/src/symlinkHandler.bat
+++ b/src/symlinkHandler.bat
@@ -1,3 +1,7 @@
+if "%GITHUB_WORKSPACE%"=="" (call) else (
+	echo "Github Actions detected, not doing symlink stuff..."
+	exit /b 0
+)
 REM First step: find Rainworld's folder
 set progfiles=C:/Program Files
 set progfiles86=C:/Program Files (x86)

--- a/src/symlinkHandler.bat
+++ b/src/symlinkHandler.bat
@@ -1,0 +1,26 @@
+REM First step: find Rainworld's folder
+set progfiles=C:/Program Files
+set progfiles86=C:/Program Files (x86)
+set rainworld=Rain World/RainWorld_Data/StreamingAssets
+if "%DeadlandsLocation%"=="" (
+	echo "'DeadLandsLocation' not defined, automatically determining Rainworld's location..."
+	if EXIST "%progfiles%/Steam/steamapps/common/%rainworld%" (
+		set DeadlandsLocation="%progfiles%/Steam/steamapps/common/%rainworld%/mods/Deadlands"
+	) else if EXIST "%progfiles86%/Steam/steamapps/common/%rainworld%" (
+		set DeadlandsLocation="%progfiles86%/Steam/steamapps/common/%rainworld%/mods/Deadlands"
+	) else if EXIST "D:/Steam/steamapps/common/%rainworld%" (
+		set DeadlandsLocation="D:/Steam/steamapps/common/%rainworld%/mods/Deadlands"
+	) else (
+		echo "Unable to find the location of Deadland's mod folder within Rainworld!'"
+		exit /b 1
+	)
+)
+REM Second: Determine if Deadlands is already there; make a symlink if it isn't
+if EXIST %DeadLandsLocation% (
+	echo "Symbolic link seemingly already exists! Cool c:"
+) else (
+	echo "Generating symbolic link for Deadlands repo..."
+	echo %DeadLandsLocation%
+	echo "%cd%"
+	mklink /d %DeadLandsLocation% "%cd%/../mod"
+)


### PR DESCRIPTION
![image](https://github.com/mills88812/Deadlands/assets/29939414/41ebf3e6-8e9b-46d4-b8be-355659cd8321)

## Summary
Whenever a build is done in VS now, this script will check if there is a symbolic link between the `mod` folder of this repo and the weird place RW mods go, and creates one if there isn't.

For those unfamiliar, this basically creates a "portal" between the two, allowing the folder to exist in basically both places at once, meaning that developers do not need to have two copies of this mod in order to develop & test it! ✨ Magic. ✨

People who choose not to compile the code may still connect the folders via invoking the script directly.

## Changelog
No user facing changes.